### PR TITLE
Refactor: HomeScreen layout, enhance navigation bar, and improve book…

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -28,9 +28,52 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Beranda', style: TextStyle(color: Colors.white)),
-        centerTitle: true,
         backgroundColor: const Color(0xFF45492F),
+        elevation: 0,
+        toolbarHeight: 80,
+        title: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Halo Alan',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.normal,
+                ),
+              ),
+              SizedBox(height: 4),
+              Text(
+                'Selamat datang!',
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.9),
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ),
+        titleSpacing: 20,
+        actions: [
+          Container(
+            margin: EdgeInsets.only(right: 20),
+            child: CircleAvatar(
+              radius: 20,
+              backgroundColor: Colors.purple.shade400,
+              child: Text(
+                'A',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
       backgroundColor: Colors.white,
       body: Column(
@@ -67,12 +110,21 @@ class _HomeScreenState extends State<HomeScreen> {
                           padding: const EdgeInsets.symmetric(horizontal: 16.0),
                           child: Column(
                             children: [
-                              RecomendationBook(bookList: bookList),
-                              SizedBox(height: 20),
-                              RecomendationBook(bookList: bookList),
-                              SizedBox(height: 20),
-                              RecomendationBook(bookList: bookList),
-                              SizedBox(height: 20),
+                              RecomendationBook(
+                                title: 'Pulau Jawa',
+                                bookList: bookList,
+                              ),
+                              SizedBox(height: 12),
+                              RecomendationBook(
+                                title: 'Pulau Sumatera',
+                                bookList: bookList,
+                              ),
+                              SizedBox(height: 12),
+                              RecomendationBook(
+                                title: 'Pulau Kalimantan',
+                                bookList: bookList,
+                              ),
+                              SizedBox(height: 48),
                             ],
                           ),
                         ),
@@ -87,6 +139,24 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
           ),
         ],
+      ),
+      floatingActionButton: Container(
+        margin: const EdgeInsets.only(bottom: 84.0),
+        child: FloatingActionButton.extended(
+          onPressed: () {
+            // Action when the button is pressed
+          },
+          backgroundColor: const Color(0xFF596420),
+          icon: const Icon(Icons.location_on, color: Colors.white),
+          label: Text(
+            'Mode Peta',
+            style: TextStyle(
+              color: Colors.white,
+              // fontSize: 10,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/screens/main/main_screen.dart
+++ b/lib/ui/screens/main/main_screen.dart
@@ -4,7 +4,7 @@ import 'package:folkloria/ui/screens/favorite/favorite_screen.dart';
 import 'package:folkloria/ui/screens/home/home_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:folkloria/ui/screens/setting/setting_page.dart';
-// import 'package:floaty_nav_bar/floaty_nav_bar.dart';
+import 'package:folkloria/ui/widgets/bottom_item_nav_widget.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -33,25 +33,57 @@ class _MainScreenState extends State<MainScreen> {
         child: ClipRRect(
           borderRadius: const BorderRadius.all(Radius.circular(80)),
           child: BottomNavigationBar(
+            backgroundColor: const Color(0xFFF0EEE2),
             currentIndex: context.watch<IndexNavProvider>().indexBottomNavBar,
             onTap: (index) {
               context.read<IndexNavProvider>().setIndextBottomNavBar = index;
             },
-            items: const [
+            type: BottomNavigationBarType.fixed,
+            selectedItemColor: const Color(
+              0xFF1D1B20,
+            ), // Putih untuk text yang dipilih
+            unselectedItemColor: const Color(
+              0xFF45492F,
+            ), // Hijau tua untuk text yang tidak dipilih
+            selectedLabelStyle: const TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 12,
+              color: Colors.white, // Putih untuk label yang dipilih
+            ),
+            unselectedLabelStyle: const TextStyle(
+              fontWeight: FontWeight.normal,
+              fontSize: 11,
+              color: Color(
+                0xFF45492F,
+              ), // Hijau tua untuk label yang tidak dipilih
+            ),
+            items: [
               BottomNavigationBarItem(
-                icon: Icon(Icons.home),
-                label: "Home",
-                tooltip: "Home",
+                icon: BottomItemNavWidget(
+                  icon: Icons.location_on,
+                  isSelected:
+                      context.watch<IndexNavProvider>().indexBottomNavBar == 0,
+                ),
+                label: "Beranda",
+                tooltip: "Beranda",
               ),
               BottomNavigationBarItem(
-                icon: Icon(Icons.bookmark),
-                label: "Favorites",
-                tooltip: "Favorites",
+                icon: BottomItemNavWidget(
+                  icon: Icons.bookmark_outline,
+                  isSelected:
+                      context.watch<IndexNavProvider>().indexBottomNavBar == 1,
+                ),
+                label: "Buku",
+                tooltip: "Buku",
               ),
               BottomNavigationBarItem(
-                icon: Icon(Icons.settings),
-                label: "Settings",
-                tooltip: "Settings",
+                icon: BottomItemNavWidget(
+                  icon: Icons.person_outline,
+                  isSelected:
+                      context.watch<IndexNavProvider>().indexBottomNavBar == 2,
+                ),
+                label: "Profil",
+                tooltip: "Profil",
               ),
             ],
           ),

--- a/lib/ui/widgets/book_recomendation_card_widget.dart
+++ b/lib/ui/widgets/book_recomendation_card_widget.dart
@@ -16,35 +16,61 @@ class BookRecomendationCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
-      child: Column(
-        children: [
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            spacing: 10,
-            children: [
-              Image.network(
-                '$baseUrl/images/small/${book.pictureId}',
-                width: 142,
-                height: 200,
-                fit: BoxFit.cover,
+      child: SizedBox(
+        width: 140, // Fixed width to prevent overflow
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 140,
+              height: 200,
+              decoration: BoxDecoration(borderRadius: BorderRadius.circular(8)),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.network(
+                  '$baseUrl/images/small/${book.pictureId}',
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) {
+                    return Container(
+                      color: Colors.grey[200],
+                      child: const Icon(
+                        Icons.book,
+                        size: 40,
+                        color: Colors.grey,
+                      ),
+                    );
+                  },
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) return child;
+                    return Container(
+                      color: Colors.grey[200],
+                      child: const Center(child: CircularProgressIndicator()),
+                    );
+                  },
+                ),
               ),
-              const SizedBox(height: 8),
-              Text(
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: 140,
+              child: Text(
                 book.name,
-                style: TextStyle(
+                style: const TextStyle(
                   color: Colors.black,
                   fontSize: 14,
                   fontFamily: 'Roboto',
-                  fontWeight: FontWeight.w700,
-                  height: 1.43,
+                  fontWeight: FontWeight.w800,
+                  height: 1.2,
                   letterSpacing: 0.25,
                 ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.start,
               ),
-            ],
-          ),
-        ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/bottom_item_nav_widget.dart
+++ b/lib/ui/widgets/bottom_item_nav_widget.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class BottomItemNavWidget extends StatelessWidget {
+  final IconData icon;
+  final bool isSelected;
+  const BottomItemNavWidget({
+    super.key,
+    required this.icon,
+    required this.isSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: isSelected
+            ? const Color(0xFFE2E5C2) // Hijau tua seperti di gambar
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Icon(
+        icon,
+        color: isSelected ? const Color(0xFF1D1B20) : const Color(0xFF45492F),
+        size: 24,
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/recomendation_book_widget.dart
+++ b/lib/ui/widgets/recomendation_book_widget.dart
@@ -4,9 +4,13 @@ import 'package:folkloria/ui/widgets/book_recomendation_card_widget.dart';
 import 'package:folkloria/common/static/navigation_route.dart';
 
 class RecomendationBook extends StatelessWidget {
-  const RecomendationBook({super.key, required this.bookList});
-
   final List<Book> bookList;
+  final String title;
+  const RecomendationBook({
+    super.key,
+    required this.bookList,
+    this.title = 'Rekomendasi Buku',
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -15,36 +19,54 @@ class RecomendationBook extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
-              'Rekomendasi Buku',
-              textAlign: TextAlign.start,
-              style: TextStyle(
-                color: Colors.black,
-                fontSize: 22,
-                fontFamily: 'Roboto',
-                fontWeight: FontWeight.w700,
-                height: 1.27,
+            Expanded(
+              child: Text(
+                title,
+                textAlign: TextAlign.start,
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontSize: 20,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w800,
+                  height: 1.27,
+                ),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
               ),
             ),
-            TextButton.icon(
-              onPressed: () {
-                // Navigator.pushNamed(
-                // context,
-                // NavigationRoute.recommendationRoute.name,
-                // );
-              },
-              icon: const Icon(Icons.arrow_forward, color: Colors.black),
-              iconAlignment: IconAlignment.end,
-              label: const Text(
-                'Lihat Semua',
-                textAlign: TextAlign.center,
-                style: TextStyle(
+            const SizedBox(width: 8),
+            Flexible(
+              child: TextButton.icon(
+                onPressed: () {
+                  // Navigator.pushNamed(
+                  // context,
+                  // NavigationRoute.recommendationRoute.name,
+                  // );
+                },
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  minimumSize: Size.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                icon: const Icon(
+                  Icons.arrow_forward,
                   color: Colors.black,
-                  fontSize: 12,
-                  fontFamily: 'Roboto',
-                  fontWeight: FontWeight.w400,
-                  height: 1.33,
-                  letterSpacing: 0.40,
+                  size: 16,
+                ),
+                iconAlignment: IconAlignment.end,
+                label: const Text(
+                  'Lihat Semua',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontSize: 12,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.33,
+                    letterSpacing: 0.40,
+                  ),
                 ),
               ),
             ),
@@ -53,27 +75,36 @@ class RecomendationBook extends StatelessWidget {
         const SizedBox(height: 8.0),
         SizedBox(
           height: 250.0,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            itemCount: bookList.length,
-            itemBuilder: (context, index) {
-              final book = bookList[index];
+          child: bookList.isEmpty
+              ? const Center(
+                  child: Text(
+                    'Tidak ada buku tersedia',
+                    style: TextStyle(color: Colors.grey, fontSize: 14),
+                  ),
+                )
+              : ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: bookList.length,
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                  itemBuilder: (context, index) {
+                    final book = bookList[index];
 
-              return Padding(
-                padding: const EdgeInsets.only(right: 10.0),
-                child: BookRecomendationCard(
-                  book: book,
-                  onTap: () {
-                    Navigator.pushNamed(
-                      context,
-                      NavigationRoute.detailRoute.name,
-                      arguments: book.id,
+                    return Container(
+                      width: 140, // Fixed width to prevent overflow
+                      margin: const EdgeInsets.only(right: 10.0),
+                      child: BookRecomendationCard(
+                        book: book,
+                        onTap: () {
+                          Navigator.pushNamed(
+                            context,
+                            NavigationRoute.detailRoute.name,
+                            arguments: book.id,
+                          );
+                        },
+                      ),
                     );
                   },
                 ),
-              );
-            },
-          ),
         ),
       ],
     );


### PR DESCRIPTION
This pull request introduces several UI improvements and refactors to the home and main screens, as well as the book recommendation widgets. The main focus is on enhancing the user experience by updating the appearance and behavior of navigation elements, the app bar, and the book recommendation cards. Additionally, new widgets are introduced for better code organization and reusability.

### Home Screen UI Enhancements

* Redesigned the `AppBar` in `home_screen.dart` to display a personalized greeting, updated layout, and a profile avatar, with adjusted elevation and height for a more modern look.
* Added a floating action button labeled "Mode Peta" with a location icon, positioned above the bottom navigation bar.
* Updated the book recommendation sections to display region-specific titles ("Pulau Jawa", "Pulau Sumatera", "Pulau Kalimantan") instead of repeating the same widget, and adjusted spacing for improved readability.

### Main Screen Navigation Improvements

* Introduced the custom `BottomItemNavWidget` for navigation bar icons, allowing for dynamic styling based on selection state and improved visual consistency. [[1]](diffhunk://#diff-843fa10319cec3b9fa324a6dd01c0782a7e5711ab8b9313ecc932654bbb5e23aR1-R29) [[2]](diffhunk://#diff-3c13d2304bb7055271e743d2a772f0f7706ef89ba6f68cf9632faa2d3b49a1a5L7-R7)
* Refactored the `BottomNavigationBar` in `main_screen.dart` to use updated labels ("Beranda", "Buku", "Profil"), custom colors, and styles for selected/unselected states, and switched to a fixed navigation bar type for better layout control.

### Book Recommendation Widget Updates

* Enhanced the `BookRecomendationCard` widget to prevent overflow by setting fixed width, improved image loading/error handling, and updated text styling for better readability.
* Refactored `RecomendationBook` to accept a customizable title, improved header layout with better text overflow handling, and added a conditional empty state message when no books are available. [[1]](diffhunk://#diff-37049a2f4fc9743451794f73a9aa4a59de57b1d2b21ef1d93e20c31d3d38f374L7-R13) [[2]](diffhunk://#diff-37049a2f4fc9743451794f73a9aa4a59de57b1d2b21ef1d93e20c31d3d38f374L18-L40) [[3]](diffhunk://#diff-37049a2f4fc9743451794f73a9aa4a59de57b1d2b21ef1d93e20c31d3d38f374R72-R94)